### PR TITLE
Add content JSON type in headers when deleting a document

### DIFF
--- a/lib/jquery/nuxeo.js
+++ b/lib/jquery/nuxeo.js
@@ -476,6 +476,7 @@ var nuxeo = (function(nuxeo) {
       callback = options;
       options = {};
     }
+    this.headers({ 'Content-Type': 'application/json' });
     options = jQuery.extend(true, options, {
       method: 'delete'
     });


### PR DESCRIPTION
## With Nuxeo 5.8 : 

When the `Content-Type` is not set to `'application/json'`, an exception is thrown by the JAX-RS 
`Exception in JAX-RS processing javax.ws.rs.WebApplicationException`

This exception disappears when the `'Content-type'` is set, and the deletion is properly made on Nuxeo platform.
