### PR TITLE
Bug fix : post multipart data instanceof restler.File and not Object

### DIFF
--- a/lib/node/nuxeo.js
+++ b/lib/node/nuxeo.js
@@ -755,7 +755,9 @@ Uploader.prototype.uploadFiles = function() {
 
   this._sendingRequestsInProgress = true;
   while (this._uploadStack.length > 0) {
-    var file = this._uploadStack.shift();
+    var fileobject = this._uploadStack.shift();
+    var file = rest.file(fileobject.path, fileobject.filename, fileobject.fileSize, fileobject.encoding, fileobject.contentType);
+    file.callback = fileobject.callback;
     file.fileIndex = this._uploadIndex + 0;
     file.downloadStartTime = new Date().getTime();
 


### PR DESCRIPTION
When shifting a file from the stack we need to create a new "rest.file".
This is done in order to post a multipart data that is an instance of "restler.File" and not a simple javascript "Object".