### PR TITLE
Fix callback calls for nuxeo requests

### DIFF
--- a/lib/node/nuxeo.js
+++ b/lib/node/nuxeo.js
@@ -507,6 +507,7 @@ Request.prototype.execute = function(options, callback) {
     callback = options;
     options = {};
   }
+  callback = callback || function() {};
   options = options || {};
   options.timeout = this._timeout;
   options.method = options.method || 'GET';
@@ -536,18 +537,12 @@ Request.prototype.execute = function(options, callback) {
 
   nuxeoRequest(path, options,
     function(err, res, body) {
-      if (err && callback) {
+      if (err) {
         callback(err, null, res);
-      }
-
-      if (res.statusCode >= 200 && res.statusCode < 300) {
-        if (callback) {
-          callback(null, body, res);
-        }
+      } else if (res.statusCode >= 200 && res.statusCode < 300) {
+        callback(null, body, res);
       } else {
-        if (callback) {
-          callback(body, null, res);
-        }
+        callback(body, null, res);
       }
     }
   );


### PR DESCRIPTION
This aims to handle callback calls errors.
e.g. if nuxeo lose Internet connection, `res` variable is empty and the error callback is not the only one being called, and it passes through that test: `res.statusCode >= 200 && res.statusCode < 300`.