### PR TITLE
Allow to pass custom Certification Authority to request module

### DIFF
--- a/lib/node/nuxeo.js
+++ b/lib/node/nuxeo.js
@@ -111,6 +111,12 @@ var Client = function(options) {
   this._headers = options.headers || {};
   this._timeout = options.timeout;
   this.connected = false;
+
+  if (options.ca != null) {
+    nuxeoRequest = nuxeoRequest.defaults({
+      ca: options.ca
+    });
+  }
 };
 
 Client.prototype._computeAuthentication = function(headers) {


### PR DESCRIPTION
For projects communicating with Nuxeo endpoints with HTTPS enabled,
it can be useful to provide a custom or private Certificate Authority.

The request module supports this with an option : "ca".