### PR TITLE
Expose jqXHR-Promise

### DIFF
--- a/lib/jquery/nuxeo.js
+++ b/lib/jquery/nuxeo.js
@@ -62,7 +62,7 @@ var nuxeo = (function(nuxeo) {
     headers = this._computeAuthentication(headers);
     headers['Accept'] = 'application/json';
 
-    jQuery.ajax({
+    return jQuery.ajax({
         type: 'POST',
         url: join(this._automationURL, 'login'),
         headers: headers,
@@ -126,7 +126,7 @@ var nuxeo = (function(nuxeo) {
       'Accept': 'application/json'
     };
 
-    jQuery.ajax({
+    return jQuery.ajax({
         type: 'GET',
         url: this._automationURL,
         headers: headers,
@@ -334,7 +334,7 @@ var nuxeo = (function(nuxeo) {
       xhrParams.contentType = 'application/json+nxrequest';
     }
 
-    jQuery.ajax(xhrParams)
+    return jQuery.ajax(xhrParams)
       .done(function(data, textStatus, jqXHR) {
         if (callback) {
           callback(null, data, jqXHR);
@@ -536,7 +536,7 @@ var nuxeo = (function(nuxeo) {
       }
     };
 
-    jQuery.ajax(xhrParams)
+    return jQuery.ajax(xhrParams)
       .done(function(data, textStatus, jqXHR) {
         if (callback) {
           callback(null, data, jqXHR);
@@ -874,7 +874,7 @@ var nuxeo = (function(nuxeo) {
       }
 
       var self = this;
-      jQuery.ajax({
+      return jQuery.ajax({
         type: 'POST',
         url: join(this._url, 'upload'),
         headers: headers,
@@ -1005,7 +1005,7 @@ var nuxeo = (function(nuxeo) {
       xhrFields: this._client._xhrFields
     };
 
-    jQuery.ajax(xhrParams)
+    return jQuery.ajax(xhrParams)
       .done(function(data, textStatus, jqXHR) {
         if (callback) {
           callback(null, data, jqXHR);

--- a/lib/jquery/nuxeo.js
+++ b/lib/jquery/nuxeo.js
@@ -432,7 +432,7 @@ var nuxeo = (function(nuxeo) {
     options = jQuery.extend(true, {}, options, {
       method: 'get'
     });
-    this.execute(options, callback);
+    return this.execute(options, callback);
   };
 
   Request.prototype.post = function(options, callback) {
@@ -450,7 +450,7 @@ var nuxeo = (function(nuxeo) {
     options = jQuery.extend(true, options, {
       method: 'post'
     });
-    this.execute(options, callback);
+    return this.execute(options, callback);
   };
 
   Request.prototype.put = function(options, callback) {
@@ -468,7 +468,7 @@ var nuxeo = (function(nuxeo) {
     options = jQuery.extend(true, options, {
       method: 'put'
     });
-    this.execute(options, callback);
+    return this.execute(options, callback);
   };
 
   Request.prototype.delete = function(options, callback) {
@@ -483,7 +483,7 @@ var nuxeo = (function(nuxeo) {
     options = jQuery.extend(true, options, {
       method: 'delete'
     });
-    this.execute(options, callback);
+    return this.execute(options, callback);
   };
 
   Request.prototype.execute = function(options, callback) {


### PR DESCRIPTION
I exposed the jqXHR-Promise (return value of jQuery.ajax) so that I can use it like:

```js
var request = client.request('...').get();
request.then(function(){
    //Success
},
function(){
    //Failure
});
```

Maybe other users want to do that too...