### PR TITLE
NXJS-94: only keep a default http timeout

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -8,7 +8,7 @@ const DEFAULT_OPTS = {
   enrichers: {},
   fetchProperties: {},
   headers: {},
-  timeout: 30000,
+  httpTimeout: 30000,
 };
 
 /**

--- a/lib/nuxeo.js
+++ b/lib/nuxeo.js
@@ -172,9 +172,10 @@ class Nuxeo extends Base {
       options.headers.depth = options.depth;
     }
 
-    const transactionTimeout = options.transactionTimeout || options.timeout;
-    const httpTimeout = options.httpTimeout || (5 + transactionTimeout);
-    options.headers['Nuxeo-Transaction-Timeout'] = transactionTimeout;
+    const { httpTimeout, transactionTimeout } = this._computeTimeouts(options);
+    if (transactionTimeout) {
+      options.headers['Nuxeo-Transaction-Timeout'] = transactionTimeout;
+    }
     options.timeout = httpTimeout;
 
     if (options.json) {
@@ -195,6 +196,16 @@ class Nuxeo extends Base {
       options.url += qs.stringify(options.queryParams);
     }
     return options;
+  }
+
+  _computeTimeouts(options) {
+    const transactionTimeout = options.transactionTimeout || options.timeout;
+    let httpTimeout = options.httpTimeout;
+    if (!httpTimeout && transactionTimeout) {
+      // make the http timeout a bit longer than the transaction timeout
+      httpTimeout = 5 + transactionTimeout;
+    }
+    return { httpTimeout, transactionTimeout };
   }
 
   /**

--- a/test/base.spec.js
+++ b/test/base.spec.js
@@ -9,8 +9,8 @@ describe('Base', () => {
     expect(base._baseOptions.enrichers).to.be.eql({});
     expect(base._baseOptions.fetchProperties).to.be.eql({});
     expect(base._baseOptions.depth).to.be.undefined();
-    expect(base._baseOptions.timeout).to.be.equal(30000);
-    expect(base._baseOptions.httpTimeout).to.be.undefined();
+    expect(base._baseOptions.timeout).to.be.undefined();
+    expect(base._baseOptions.httpTimeout).to.be.equal(30000);
     expect(base._baseOptions.transactionTimeout).to.be.undefined();
   });
 

--- a/test/nuxeo.spec.js
+++ b/test/nuxeo.spec.js
@@ -48,6 +48,41 @@ describe('Nuxeo', () => {
     expect(n._auth.password).to.be.equal('Administrator');
   });
 
+  it('should have neither default \'transactionTimeout\' nor \'timeout\' set', () => {
+    const n = new Nuxeo();
+    expect(n._baseOptions.transactionTimeout).to.be.undefined();
+    expect(n._baseOptions.timeout).to.be.undefined();
+    expect(n._baseOptions.httpTimeout).to.be.equal(30000);
+  });
+
+  describe('#_computeTimeouts', () => {
+    it('should use \'timeout\' for both \'httpTimeout\' and \'transactionTimeout\'', () => {
+      const { httpTimeout, transactionTimeout } = nuxeo._computeTimeouts({ timeout: 25000 });
+      expect(transactionTimeout).to.be.equal(25000);
+      expect(httpTimeout).to.be.equal(25000 + 5);
+    });
+
+    it('should use \'httpTimeout\' if defined', () => {
+      const { httpTimeout, transactionTimeout } = nuxeo._computeTimeouts({ timeout: 10000, httpTimeout: 20000 });
+      expect(httpTimeout).to.be.equal(20000);
+      expect(transactionTimeout).to.be.equal(10000);
+    });
+
+    it('should use \'transactionTimeout\' for both \'httpTimeout\' and \'transactionTimeout\' if defined', () => {
+      const { httpTimeout, transactionTimeout } = nuxeo._computeTimeouts({ transactionTimeout: 10000 });
+      expect(transactionTimeout).to.be.equal(10000);
+      expect(httpTimeout).to.be.equal(10000 + 5);
+    });
+
+    it('should ignore \'timeout\'', () => {
+      const { httpTimeout, transactionTimeout } = nuxeo._computeTimeouts({
+        timeout: 10000, httpTimeout: 50000, transactionTimeout: 30000,
+      });
+      expect(transactionTimeout).to.be.equal(30000);
+      expect(httpTimeout).to.be.equal(50000);
+    });
+  });
+
   describe('#login', () => {
     it('should login and retrieve the logged in user', () => {
       return nuxeo.login().then((user) => {


### PR DESCRIPTION
Keep the transaction timeout undefined by default so that the server side configuration is used.