### PR TITLE
Fix extra / in oauth resulting in wrong url

### DIFF
--- a/lib/auth/oauth2.js
+++ b/lib/auth/oauth2.js
@@ -7,7 +7,7 @@ const Promise = require('../deps/promise');
 const fetchAccessToken = (baseURL, body) => {
   const url = baseURL.endsWith('/') ? baseURL : `${baseURL}/`;
   return new Promise((resolve, reject) => (
-    doFetch(`${url}/oauth2/token`, {
+    doFetch(`${url}oauth2/token`, {
       method: 'POST',
       body: qs.stringify(body),
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },


### PR DESCRIPTION
I didn't understand why I was getting `https://***.apps.prod.nuxeo.io/nuxeo//oauth2/token` as an url.